### PR TITLE
Update regex to check for valid AWS Key ID prefixes

### DIFF
--- a/gitsecrets/__init__.py
+++ b/gitsecrets/__init__.py
@@ -16,8 +16,10 @@ class GitSecrets(object):
     id = r'(ID|id|Id)'
     key = r'(KEY|key|Key)'
     under = r'_'
-    raw_access_key_pattern = r'^[A-Z0-9]{20}$'
-    access_key_pattern = r'[A-Z0-9]{20}'
+    # This pattern is more specific than the previous which would trigger false positives.
+    # Changed in git-secrets PR: https://github.com/awslabs/git-secrets/pull/89
+    raw_access_key_pattern = r'^(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}$'
+    access_key_pattern = r'(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'
     raw_secret_access_key_pattern = r'^[0-9a-zA-Z]{40}$'
     secret_access_key_pattern = r'[0-9a-zA-Z]{40}'
     secret_access_key_regex = opt_quote + aws + under + secret + under + access + under + key + opt_quote + \
@@ -26,7 +28,7 @@ class GitSecrets(object):
                        access_key_pattern + opt_quote
 
     default_patterns = [
-        raw_access_key_pattern,         # AWS Access Key ID
+        raw_access_key_pattern,          # AWS Access Key ID
         raw_secret_access_key_pattern,   # AWS Secret Access Key
         access_key_regex,
         secret_access_key_regex

--- a/test_driver.py
+++ b/test_driver.py
@@ -68,11 +68,16 @@ class TestGitSecrets(GSTestCase):
         self.assertIsNone(self.gs.scan_file('tests/tempdir/plain.txt'))
         self.cleanupfile('tests/tempdir/plain.txt')
 
-    def test_aws_creds_access_key_id(self):
-        key = ''.join(random.choice(ascii_uppercase) for _ in range(20))
-        self.newfile('tests/tempdir/aws-credentials', "aws_access_key_id=" + key)
-        self.assertTrue(self.gs.scan_file('tests/tempdir/aws-credentials'))
-        self.cleanupfile('tests/tempdir/aws-credentials')
+    def test_new_aws_creds_access_key_id(self):
+        patterns = [''.join("A3T" + random.choice(ascii_uppercase)), 'AKIA',
+                    'AGPA', 'AIDA', 'AROA', 'AIPA', 'ANPA', 'ANVA', 'ASIA']
+        for item in patterns:
+            generated = ''.join(random.choice(ascii_uppercase) for _ in range(16))
+            key = ''.join(item + generated)
+            # print("testing pattern: \'{}\'".format(key))  # DEBUG
+            self.newfile('tests/tempdir/aws-credentials', "aws_access_key_id=" + key)
+            self.assertTrue(self.gs.scan_file('tests/tempdir/aws-credentials'))
+            self.cleanupfile('tests/tempdir/aws-credentials')
 
     def test_aws_creds_secret_access_key(self):
         chars = ascii_uppercase + ascii_lowercase + digits
@@ -130,7 +135,7 @@ class TestAWSLabsGitSecrets(GSTestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(TestGitSecrets('test_plain_text'))
-    suite.addTest(TestGitSecrets('test_aws_creds_access_key_id'))
+    suite.addTest(TestGitSecrets('test_new_aws_creds_access_key_id'))
     suite.addTest(TestGitSecrets('test_aws_creds_secret_access_key'))
     suite.addTest(TestGitSecrets('test_add_pattern'))
     suite.addTest(TestGitSecrets('test_binary_file'))


### PR DESCRIPTION
Fixes: https://github.com/mbacchi/python-git-secrets/issues/11